### PR TITLE
Csv file error

### DIFF
--- a/join.py
+++ b/join.py
@@ -17,7 +17,7 @@ def loadCSV(fn,header=False,DELIM="|",QUOTECHAR='"'):
     csvReader = csv.reader(f, delimiter=DELIM, quotechar=QUOTECHAR)
     
     if header:
-        headerLine = csvReader.next()
+        headerLine = next(csvReader)
 
     data = []
     for row in csvReader:

--- a/join.py
+++ b/join.py
@@ -13,7 +13,7 @@ import argparse
 
 def loadCSV(fn,header=False,DELIM="|",QUOTECHAR='"'):
     
-    f = open(fn,"rb")
+    f = open(fn,"r")
     csvReader = csv.reader(f, delimiter=DELIM, quotechar=QUOTECHAR)
     
     if header:
@@ -100,7 +100,7 @@ def main():
     outputFn = args.outputFn
     joinType = args.joinType
 
-    f = open(outputFn, 'wb')
+    f = open(outputFn, 'w')
     csvWriter = csv.writer(f, delimiter=',',quotechar='"', quoting=csv.QUOTE_MINIMAL)
     csvWriter.writerow(leftHeader + rightHeader)
 


### PR DESCRIPTION
- The csvs where opened in the bytes mode, this cause some errors in python 3
- In python 3 the _csv.reader module don't have an next method, in this case we should use next build-in